### PR TITLE
ci: add mulitarch docker image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,18 +3,34 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - main  # main 브랜치에 push 될 때마다 실행
+      - main
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/mcp-bybit-server
 
 jobs:
-  build-and-push:
+  build-docker:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -22,9 +38,73 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/mcp-bybit-server:latest
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${RUNNER_TEMP}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: "${{ runner.temp }}/digests/*"
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-docker
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: "${{ runner.temp }}/digests"
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Create manifest list and push
+        working-directory: "${{ runner.temp }}/digests"
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,24 @@ Make sure you have pulled the image first: `docker pull dlwjdtn535/mcp-bybit-ser
 }
 ```
 
+**Using Docker with .env (Requires Docker)**
+
+Make sure you have pulled the image first: `docker pull dlwjdtn535/mcp-bybit-server:latest`
+
+```json
+{
+  "mcpServers": {
+    "bybit-server-docker": {
+      "command": "/bin/sh",
+      "args": [
+        "-c",
+        "source .env && docker run -i --rm --init -e ACCESS_KEY=$BYBIT_API_KEY -e SECRET_KEY=$BYBIT_API_SECRET -e TESTNET=true dlwjdtn535/mcp-bybit-server:latest"
+      ]
+    }
+  }
+}
+```
+
 > **Note**: Always use `@latest` or a specific version tag for both NPX and Docker to ensure you are using the intended version.
 
 ## Tools 🛠️

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,7 @@ class Config:
     MEMBER_ID = os.getenv("MEMBER_ID")
     ACCESS_KEY = os.getenv("ACCESS_KEY")
     SECRET_KEY = os.getenv("SECRET_KEY")
-    TESTNET = False
+    TESTNET = os.getenv("TESTNET", False).lower() == "true"
 
     @classmethod
     def log_config(cls):


### PR DESCRIPTION
Allow to run in linux/arm64 arch

Because while testing on my macos arm, this was not working, so I take the liberty to open this PR ;) 

I also update the readme to make mcp use the .env directly to avoid exposing the secrets in .mcp.json file.