### PR TITLE
fix(security): remove credential exposure and add trading safeguards

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,17 +7,24 @@ load_dotenv(verbose=True)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Maksymalny rozmiar zlecenia w USDT (zabezpieczenie przed przypadkowym duzym zleceniem)
+MAX_ORDER_SIZE_USDT = float(os.getenv("MAX_ORDER_SIZE_USDT", "100"))
+
 class Config:
     MEMBER_ID = os.getenv("MEMBER_ID")
     ACCESS_KEY = os.getenv("ACCESS_KEY")
     SECRET_KEY = os.getenv("SECRET_KEY")
-    TESTNET = os.getenv("TESTNET", False).lower() == "true"
+    TESTNET = os.getenv("TESTNET", "false").lower() == "true"
+    TRADING_ENABLED = os.getenv("TRADING_ENABLED", "false").lower() == "true"
 
     @classmethod
     def log_config(cls):
-        logger.info(f"MEMBER_ID: {cls.MEMBER_ID}")
-        logger.info(f"ACCESS_KEY: {cls.ACCESS_KEY}")
+        # BEZPIECZENSTWO: logujemy TYLKO czy klucz istnieje, NIGDY wartosc
+        logger.info(f"ACCESS_KEY configured: {'YES' if cls.ACCESS_KEY else 'NO'}")
+        logger.info(f"SECRET_KEY configured: {'YES' if cls.SECRET_KEY else 'NO'}")
         logger.info(f"TESTNET: {cls.TESTNET}")
+        logger.info(f"TRADING_ENABLED: {cls.TRADING_ENABLED}")
+        logger.info(f"MAX_ORDER_SIZE_USDT: {MAX_ORDER_SIZE_USDT}")
 
 # Log configuration
 Config.log_config()

--- a/src/server.py
+++ b/src/server.py
@@ -15,42 +15,16 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Log environment variables
-logger.debug("Current environment variables:")
-for key, value in os.environ.items():
-    if key in ["MEMBER_ID", "ACCESS_KEY", "SECRET_KEY", "TESTNET"]:
-        logger.debug(f"{key}: {value}")
+# BEZPIECZENSTWO: NIE logujemy kluczy API
 
 # Create BybitService instance
 bybit_service = BybitService()
 
-# Register MCP tools
-mcp = FastMCP(
-    env={
-        "ACCESS_KEY": os.getenv("ACCESS_KEY"),
-        "SECRET_KEY": os.getenv("SECRET_KEY"),
-    }
-)
+# BEZPIECZENSTWO: NIE przekazujemy kluczy do MCP env
+# BEZPIECZENSTWO: USUNIETO get_secret_key() i get_access_key() -- LLM NIE moze wyciagnac kluczy
+mcp = FastMCP()
 
-@mcp.tool()
-def get_secret_key(
-) -> str:
-    """
-    Get secret key from environment variables
-    :return: Secret key
-    """
-    return os.getenv("SECRET_KEY")
-
-@mcp.tool()
-def get_access_key(
-) -> str:
-    """
-    Get access key from environment variables
-    :return: Access key
-    """
-    return os.getenv("ACCESS_KEY")
-
-# Register MCP tools
+from config import Config
 @mcp.tool()
 def get_orderbook(
     category: str = Field(description="Category (spot, linear, inverse, etc.)"),
@@ -336,12 +310,39 @@ def place_order(
         https://bybit-exchange.github.io/docs/v5/order/create-order
     """
     try:
+        # BEZPIECZENSTWO: Trading musi byc jawnie wlaczony
+        if not Config.TRADING_ENABLED:
+            return {"error": "Trading is DISABLED. Set TRADING_ENABLED=true to enable."}
+
+        # BEZPIECZENSTWO: Walidacja inputow
+        if side not in ("Buy", "Sell"):
+            return {"error": f"Invalid side: {side}. Must be 'Buy' or 'Sell'."}
+        if orderType not in ("Market", "Limit"):
+            return {"error": f"Invalid orderType: {orderType}. Must be 'Market' or 'Limit'."}
+        if category not in ("spot", "linear", "inverse", "option"):
+            return {"error": f"Invalid category: {category}. Must be 'spot', 'linear', 'inverse', or 'option'."}
+
+        # BEZPIECZENSTWO: Max order size check
+        from config import MAX_ORDER_SIZE_USDT
+        try:
+            qty_float = float(qty)
+            if category == "spot" and side == "Buy" and orderType == "Market":
+                # Market buy na spot -- qty jest w USDT
+                if qty_float > MAX_ORDER_SIZE_USDT:
+                    return {"error": f"Order size {qty} USDT exceeds max {MAX_ORDER_SIZE_USDT} USDT. Adjust MAX_ORDER_SIZE_USDT env var."}
+        except ValueError:
+            return {"error": f"Invalid qty: {qty}. Must be a number."}
+
         result = bybit_service.place_order(
-            category, symbol, side, orderType, qty, price, positionIdx,
-            timeInForce, orderLinkId, isLeverage, orderFilter,
-            triggerPrice, triggerBy, orderIv, takeProfit,
-            stopLoss, tpTriggerBy, slTriggerBy, tpLimitPrice,
-            slLimitPrice, tpOrderType, slOrderType
+            category=category, symbol=symbol, side=side, orderType=orderType,
+            qty=qty, price=price, positionIdx=positionIdx,
+            timeInForce=timeInForce, orderLinkId=orderLinkId,
+            isLeverage=isLeverage, orderFilter=orderFilter,
+            triggerPrice=triggerPrice, triggerBy=triggerBy, orderIv=orderIv,
+            takeProfit=takeProfit, stopLoss=stopLoss,
+            tpTriggerBy=tpTriggerBy, slTriggerBy=slTriggerBy,
+            tpLimitPrice=tpLimitPrice, slLimitPrice=slLimitPrice,
+            tpOrderType=tpOrderType, slOrderType=slOrderType
         )
         if result.get("retCode") != 0:
             logger.error(f"Failed to place order: {result.get('retMsg')}")
@@ -380,6 +381,8 @@ def cancel_order(
         https://bybit-exchange.github.io/docs/v5/order/cancel-order
     """
     try:
+        if not Config.TRADING_ENABLED:
+            return {"error": "Trading is DISABLED. Set TRADING_ENABLED=true to enable."}
         result = bybit_service.cancel_order(category, symbol, orderId, orderLinkId, orderFilter)
         if result.get("retCode") != 0:
             logger.error(f"Failed to cancel order: {result.get('retMsg')}")
@@ -670,11 +673,7 @@ def main():
         logger.info("MCP server starting...")
         print("MCP server starting...", file=sys.stderr)
 
-        # Log environment variables again
-        logger.debug("Server start environment variables:")
-        for key, value in os.environ.items():
-            if key in ["MEMBER_ID", "ACCESS_KEY", "SECRET_KEY", "TESTNET"]:
-                logger.debug(f"{key}: {value}")
+        # BEZPIECZENSTWO: NIE logujemy kluczy API
 
         mcp.run(transport="stdio")
     except Exception as e:

--- a/src/service.py
+++ b/src/service.py
@@ -28,7 +28,7 @@ class BybitService:
         """
         Initialize BybitService
         """
-        logger.info(f"Initializing Bybit Service - Testnet: {Config.TESTNET}, API Key: {Config.ACCESS_KEY}")
+        logger.info(f"Initializing Bybit Service - Testnet: {Config.TESTNET}, API Key: {'configured' if Config.ACCESS_KEY else 'MISSING'}")
         self.client = HTTP(
             testnet=Config.TESTNET,
             api_key=Config.ACCESS_KEY,
@@ -143,10 +143,11 @@ class BybitService:
     # Order related methods
     def place_order(self, category: str, symbol: str, side: str, orderType: str,
                     qty: str, price: Optional[str] = None,
+                    positionIdx: Optional[int] = None,
                     timeInForce: Optional[str] = None, orderLinkId: Optional[str] = None,
                     isLeverage: Optional[int] = None, orderFilter: Optional[str] = None,
                     triggerPrice: Optional[str] = None, triggerBy: Optional[str] = None,
-                    orderIv: Optional[str] = None, positionIdx: Optional[int] = None,
+                    orderIv: Optional[str] = None,
                     takeProfit: Optional[str] = None, stopLoss: Optional[str] = None,
                     tpTriggerBy: Optional[str] = None, slTriggerBy: Optional[str] = None,
                     tpLimitPrice: Optional[str] = None, slLimitPrice: Optional[str] = None,


### PR DESCRIPTION
## Summary

This PR addresses **critical security vulnerabilities** and adds essential safety mechanisms for production use.

### Security Fixes (Critical)

- **Remove `get_secret_key()` and `get_access_key()` MCP tools** — These tools exposed API credentials (API key and secret) to any connected LLM via standard tool calls. A prompt injection or rogue agent could trivially extract credentials in plaintext.
- **Remove all credential logging** — `ACCESS_KEY` was logged at INFO level in `config.py` and `service.py`; `SECRET_KEY` was logged at DEBUG level in `server.py`. Now only logs whether keys are configured (`YES`/`NO`), never the actual values.
- **Remove credential passthrough via `FastMCP(env={})`** — API keys were unnecessarily passed to the MCP framework's env parameter.

### Bug Fixes

- **Fix `TESTNET` config crash** — `os.getenv("TESTNET", False).lower()` raises `AttributeError` when `TESTNET` env var is unset, because `False` (bool) has no `.lower()` method. Changed default to `"false"` (string).
- **Fix `place_order` parameter ordering** — `positionIdx` in `server.py` was passed as a positional argument that mapped to `timeInForce` in `service.py`'s function signature. Now uses explicit keyword arguments to prevent parameter misalignment.

### Safety Mechanisms (New)

- **`TRADING_ENABLED` flag** (default: `false`) — All order placement and cancellation is rejected unless explicitly enabled via environment variable. Prevents accidental trades when using the server for read-only analysis.
- **`MAX_ORDER_SIZE_USDT` limit** (default: `100`) — Rejects spot market buy orders exceeding this configurable threshold. Prevents catastrophic "fat finger" errors.
- **Input validation** — Validates `side` (`Buy`/`Sell`), `orderType` (`Market`/`Limit`), and `category` (`spot`/`linear`/`inverse`/`option`) before forwarding to the Bybit API.

### Migration Guide

No breaking changes for read-only usage. For trading:

```bash
# Enable trading (required)
export TRADING_ENABLED=true

# Optional: adjust max order size (default: 100 USDT)
export MAX_ORDER_SIZE_USDT=500
```

## Test plan

- [x] Verify server starts without crash when `TESTNET` env var is unset
- [x] Verify `get_secret_key` and `get_access_key` tools are no longer registered
- [x] Verify no credentials appear in INFO or DEBUG logs
- [x] Verify `place_order` returns error when `TRADING_ENABLED=false`
- [x] Verify `place_order` rejects invalid `side`/`orderType`/`category` values
- [x] Verify `place_order` rejects orders exceeding `MAX_ORDER_SIZE_USDT`
- [x] Verify existing read-only tools (get_orderbook, get_kline, get_tickers, etc.) work unchanged